### PR TITLE
OAS-6824 | Remove error stream support, improve log output

### DIFF
--- a/api/consts.go
+++ b/api/consts.go
@@ -28,8 +28,7 @@ const (
 	HeaderStreamType = "streamType"
 )
 const (
-	StreamTypeData  = "data"
-	StreamTypeError = "error"
+	StreamTypeData = "data"
 )
 
 // ProtocolName is the subprotocol used for port forwarding.

--- a/client/http_stream.go
+++ b/client/http_stream.go
@@ -21,7 +21,6 @@
 package client
 
 import (
-	"fmt"
 	"sync"
 
 	"errors"
@@ -30,38 +29,31 @@ import (
 	"github.com/arangodb-managed/portforward-helper/httpstream"
 )
 
-// httpStreamPair represents the error and data streams for a port
+// httpStream represents the error and data streams for a port
 // forwarding request.
-type httpStreamPair struct {
-	lock        sync.RWMutex
-	requestID   string
-	dataStream  httpstream.Stream
-	errorStream httpstream.Stream
-	complete    chan struct{}
+type httpStream struct {
+	lock       sync.RWMutex
+	requestID  string
+	dataStream httpstream.Stream
+	complete   chan struct{}
 }
 
-// newPortForwardPair creates a new httpStreamPair.
-func newPortForwardPair(requestID string) *httpStreamPair {
-	return &httpStreamPair{
+// newPortForwardStream creates a new httpStream.
+func newPortForwardStream(requestID string) *httpStream {
+	return &httpStream{
 		requestID: requestID,
 		complete:  make(chan struct{}),
 	}
 }
 
-// add adds the stream to the httpStreamPair. If the pair already
+// add adds the stream to the httpStream. If it already
 // contains a stream for the new stream's type, an error is returned. add
-// returns true if both the data and error streams for this pair have been
-// received.
-func (p *httpStreamPair) add(stream httpstream.Stream) (bool, error) {
+// returns true if all required streams are received.
+func (p *httpStream) add(stream httpstream.Stream) (bool, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	switch stream.Headers().Get(api.HeaderStreamType) {
-	case api.StreamTypeError:
-		if p.errorStream != nil {
-			return false, errors.New("error stream already assigned")
-		}
-		p.errorStream = stream
 	case api.StreamTypeData:
 		if p.dataStream != nil {
 			return false, errors.New("data stream already assigned")
@@ -69,18 +61,9 @@ func (p *httpStreamPair) add(stream httpstream.Stream) (bool, error) {
 		p.dataStream = stream
 	}
 
-	complete := p.errorStream != nil && p.dataStream != nil
+	complete := p.dataStream != nil
 	if complete {
 		close(p.complete)
 	}
 	return complete, nil
-}
-
-// printError writes s to p.errorStream if p.errorStream has been set.
-func (p *httpStreamPair) printError(s string) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	if p.errorStream != nil {
-		fmt.Fprint(p.errorStream, s)
-	}
 }

--- a/client/http_stream_handler_test.go
+++ b/client/http_stream_handler_test.go
@@ -106,13 +106,13 @@ func TestGetStream(t *testing.T) {
 	// test adding a new entry
 	p, created := h.getStream("1")
 	if p == nil {
-		t.Fatalf("unexpected nil")
+		t.Fatal("unexpected nil")
 	}
 	if !created {
 		t.Fatal("expected created=true")
 	}
 	if p.dataStream != nil {
-		t.Errorf("unexpected non-nil data stream")
+		t.Error("unexpected non-nil data stream")
 	}
 
 	// start the monitor for this stream
@@ -143,14 +143,14 @@ func TestGetStream(t *testing.T) {
 		t.Fatalf("unexpected error adding data stream: %v", err)
 	}
 	if !complete {
-		t.Fatalf("expected complete=true")
+		t.Fatal("expected complete=true")
 	}
 
 	// make sure monitorStream completed
 	<-monitorDone
 
 	if !conn.removeStreamsCalled {
-		t.Fatalf("connection remove stream not called")
+		t.Fatal("connection remove stream not called")
 	}
 	conn.removeStreamsCalled = false
 
@@ -181,7 +181,7 @@ func TestGetStream(t *testing.T) {
 		t.Fatal("expected stream to be removed")
 	}
 	if !conn.removeStreamsCalled {
-		t.Fatalf("connection remove stream not called")
+		t.Fatal("connection remove stream not called")
 	}
 }
 


### PR DESCRIPTION
Error stream currently is not used and actually is not desired for reverse-proxy scenario